### PR TITLE
Improve skills when composing or improving songs

### DIFF
--- a/src/Cli/Text.fs
+++ b/src/Cli/Text.fs
@@ -31,7 +31,7 @@ and skillName id =
     match id with
     | Composition -> "Composition"
     | Genre genre -> $"{genre} (Genre)"
-    | Instrument instrument -> $"{instrumentName instrument.Type} (Instrument)"
+    | Instrument instrument -> $"{instrumentName instrument} (Instrument)"
 
 /// Returns the correct pronoun for the given gender (he, she, they).
 and subjectPronounForGender gender =
@@ -46,6 +46,12 @@ and objectPronounForGender gender =
     | Male -> "Him"
     | Female -> "Her"
     | Other -> "Them"
+
+and possessiveAdjectiveForGender gender =
+    match gender with
+    | Male -> "His"
+    | Female -> "Her"
+    | Other -> "Its"
 
 /// Returns the correct conjugation for the given verb that matches with the
 /// specified gender.
@@ -62,6 +68,20 @@ and fromConstant constant =
     | CommonCancel -> "[bold]Cancel[/]"
     | CommonBackToMainMenu -> "[bold]Back to main menu[/]"
     | CommonPressKeyToContinue -> "Press [bold blue]any[/] key to continue"
+    | CommonSkillImproved (characterName,
+                           characterGender,
+                           skill,
+                           previousLevel,
+                           currentLevel) ->
+        String.Format(
+            "[green]{0} improved {1} {2} skill from {3}% to {4}%[/]",
+            characterName,
+            (possessiveAdjectiveForGender characterGender)
+                .ToLower(),
+            (skillName skill.Id).ToLower(),
+            previousLevel,
+            currentLevel
+        )
     | MainMenuPrompt -> "Select an option to begin"
     | MainMenuNewGame -> "New game"
     | MainMenuLoadGame -> "Load game"
@@ -140,11 +160,8 @@ and fromConstant constant =
             previousQuality,
             currentQuality
         )
-    | ImproveSongReachedMaxQuality quality ->
-        String.Format(
-            "[springgreen4]Your band has decided that the song does not need any further improvements. It has a quality of {0}%[/]. [blue]You can add it to the band's repertoire from the 'Finish an unfinished song' option[/]",
-            quality
-        )
+    | ImproveSongReachedMaxQuality ->
+        "[springgreen4]Your band has decided that the song does not need any further improvements[/]. [blue]You can add it to the band's repertoire from the 'Finish an unfinished song' option[/]"
     | ImproveSongProgressAddingSomeMelodies ->
         "[springgreen3_1]Adding some melodies...[/]"
     | ImproveSongProgressPlayingFoosball ->

--- a/src/Cli/View/Scenes/Management/Hire.fs
+++ b/src/Cli/View/Scenes/Management/Hire.fs
@@ -29,7 +29,7 @@ and memberSelection state selectedInstrument =
     let instrument =
         Instrument.createInstrument (Instrument.Type.from selectedInstrument.Id)
 
-    membersForHire state band instrument
+    membersForHire state band instrument.Type
     |> Seq.take 1
     |> Seq.map (showMemberForHire state band selectedInstrument)
     |> Seq.concat

--- a/src/Cli/View/Scenes/RehearsalRoom/ComposeSong.fs
+++ b/src/Cli/View/Scenes/RehearsalRoom/ComposeSong.fs
@@ -86,7 +86,6 @@ and handleSong state name length genre selectedVocalStyle =
 
 and composeWithProgressbar state song =
     seq {
-        yield Effect <| composeSong state song
 
         yield
             ProgressBar
@@ -100,6 +99,8 @@ and composeWithProgressbar state song =
         yield
             Message
             <| TextConstant(ComposeSongConfirmation song.Name)
+
+        yield Effect <| composeSong state song
 
         yield SceneAfterKey RehearsalRoom
     }

--- a/src/Cli/View/TextConstants.fs
+++ b/src/Cli/View/TextConstants.fs
@@ -20,6 +20,12 @@ type TextConstant =
     | CommonCancel
     | CommonBackToMainMenu
     | CommonPressKeyToContinue
+    | CommonSkillImproved of
+        characterName: string *
+        characterGender: Gender *
+        skill: Skill *
+        previousLevel: int *
+        currentLevel: int
     | MainMenuPrompt
     | MainMenuNewGame
     | MainMenuLoadGame
@@ -68,7 +74,7 @@ type TextConstant =
     | ImproveSongCanBeFurtherImproved of
         previousQuality: Quality *
         currentQuality: Quality
-    | ImproveSongReachedMaxQuality of quality: Quality
+    | ImproveSongReachedMaxQuality
     | ImproveSongProgressAddingSomeMelodies
     | ImproveSongProgressPlayingFoosball
     | ImproveSongProgressModifyingChordsFromAnotherSong

--- a/src/Common/Common.fsproj
+++ b/src/Common/Common.fsproj
@@ -13,6 +13,7 @@
         <Compile Include="List.fs" />
         <Compile Include="Tuple.fs" />
         <Compile Include="Map.fs" />
+        <Compile Include="Seq.fs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Common/Seq.fs
+++ b/src/Common/Seq.fs
@@ -1,0 +1,9 @@
+module Common.Seq
+
+/// Applies a side-effect to each element of a sequence similar to how Seq.iter
+/// works but returning the element that is being processed afterwards.
+let tap fn =
+    Seq.map
+        (fun item ->
+            fn item
+            item)

--- a/src/Entities/Types.fs
+++ b/src/Entities/Types.fs
@@ -78,7 +78,7 @@ module Types =
     type SkillId =
         | Composition
         | Genre of Genre
-        | Instrument of Instrument
+        | Instrument of InstrumentType
 
     /// Defines all possible categories to which skills can be related to.
     type SkillCategory =
@@ -158,14 +158,6 @@ module Types =
     type Quality = int<quality>
     type MaxQuality = int<quality>
 
-    /// Indicates whether the song can be further improved or if it has reached its
-    /// maximum quality and thus cannot be improved. All variants wrap an int that
-    /// hold the current value.
-    type SongStatus =
-        | CanBeImproved of Quality
-        | ReachedMaxQualityInLastImprovement of Quality
-        | ReachedMaxQualityAlready of Quality
-
     /// Shapes a relation between an unfinished song, its max quality and the
     /// current quality.
     type UnfinishedSongWithQualities = UnfinishedSong * MaxQuality * Quality
@@ -208,3 +200,12 @@ module Types =
         | SongDiscarded of Band * UnfinishedSongWithQualities
         | MemberHired of Band * CurrentMember
         | MemberFired of Band * CurrentMember * PastMember
+        | SkillImproved of Character * Diff<SkillWithLevel>
+
+    /// Indicates whether the song can be further improved or if it has reached its
+    /// maximum quality and thus cannot be improved. All variants wrap an int that
+    /// hold the current value.
+    type SongStatus =
+        | CanBeImproved of Effect
+        | ReachedMaxQualityInLastImprovement of Effect
+        | ReachedMaxQualityAlready

--- a/src/Simulation/Bands/Members.fs
+++ b/src/Simulation/Bands/Members.fs
@@ -28,7 +28,7 @@ let private createMemberForHire averageSkillLevel averageAge genre instrument =
                 Character.from name (ageFromAverage averageAge) gender
                 |> Result.unwrap
 
-        Band.MemberForHire.from npc instrument.Type skills
+        Band.MemberForHire.from npc instrument skills
 
 /// Generates an infinite sequence of available members for the given band
 /// looking for the given instrument.

--- a/src/Simulation/Galactus.fs
+++ b/src/Simulation/Galactus.fs
@@ -1,0 +1,22 @@
+/// This name was deliberately chosen because I have no idea how to properly
+/// name this module, so what's better than referencing this piece of art:
+/// https://www.youtube.com/watch?v=y8OnoxKotPQ
+module Simulation.Galactus
+
+open Entities
+open Simulation.Skills.ImproveSkills
+
+/// Takes an effect and runs all the correspondent simulation functions
+/// gathering their effects as well and adding them to a final list with all the
+/// effects that were created. Useful for situations in which an effect should
+/// trigger other effects such as starting a new song or improving an existing
+/// one, which should trigger an improvement in the band's skills.
+let runOne state effect =
+    match effect with
+    | SongStarted (band, _) ->
+        improveBandSkillsAfterComposing state band
+        |> List.append [ effect ]
+    | SongImproved (band, _) ->
+        improveBandSkillsAfterComposing state band
+        |> List.append [ effect ]
+    | _ -> [ effect ]

--- a/src/Simulation/Simulation.fsproj
+++ b/src/Simulation/Simulation.fsproj
@@ -14,11 +14,13 @@
         <Compile Include="Queries\Calendar.fs" />
         <Compile Include="Setup\StartGame.fs" />
         <Compile Include="Bands\Members.fs" />
+        <Compile Include="Skills\ImproveSkills.fs" />
         <Compile Include="Songs\Composition\Common.fs" />
         <Compile Include="Songs\Composition\ComposeSong.fs" />
         <Compile Include="Songs\Composition\ImproveSong.fs" />
         <Compile Include="Songs\Composition\FinishSong.fs" />
         <Compile Include="Songs\Composition\DiscardSong.fs" />
+        <Compile Include="Galactus.fs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Simulation/Skills/ImproveSkills.fs
+++ b/src/Simulation/Skills/ImproveSkills.fs
@@ -1,0 +1,39 @@
+module Simulation.Skills.ImproveSkills
+
+open Common
+open Entities
+open Simulation.Queries
+
+let improveSkillByOne ((skill, level): SkillWithLevel) =
+    level + 1
+    |> Tuple.two skill
+    |> fun updatedSkill -> Diff((skill, level), updatedSkill)
+
+let improveMemberSkills state (band: Band) (currentMember: CurrentMember) =
+    [ Composition
+      Genre(band.Genre)
+      Instrument(currentMember.Role) ]
+    |> List.map (
+        Skills.characterSkillWithLevel state currentMember.Character.Id
+    )
+    |> List.map (
+        improveSkillByOne
+        >> Tuple.two currentMember.Character
+    )
+
+let improveBandMembersSkills state band =
+    Bands.currentBandMembers state
+    |> List.map (improveMemberSkills state band)
+    |> List.concat
+    |> List.map SkillImproved
+
+let improveBandSkillsAfterComposing' randomBetween state band =
+    if randomBetween 0 100 > 50 then
+        improveBandMembersSkills state band
+    else
+        []
+
+/// Grants a 50% chance of improving the composition, genre and instrument of
+/// all members of the band between 0 and 5, generated random for each member.
+let improveBandSkillsAfterComposing =
+    improveBandSkillsAfterComposing' Random.between

--- a/src/Simulation/Songs/Composition/Common.fs
+++ b/src/Simulation/Songs/Composition/Common.fs
@@ -11,12 +11,13 @@ let qualityForMember state genre (currentMember: CurrentMember) =
 
     let influencingSkills =
         [ Composition
-          (Instrument
-           <| Instrument.createInstrument currentMember.Role)
+          Instrument currentMember.Role
           genreSkill.Id ]
 
     influencingSkills
-    |> List.map (Skills.characterSkillWithLevel state currentMember.Character.Id)
+    |> List.map (
+        Skills.characterSkillWithLevel state currentMember.Character.Id
+    )
     |> List.map snd
     |> List.sum
     |> fun total -> total / influencingSkills.Length

--- a/src/Simulation/Songs/Composition/ImproveSong.fs
+++ b/src/Simulation/Songs/Composition/ImproveSong.fs
@@ -2,8 +2,9 @@ module Simulation.Songs.Composition.ImproveSong
 
 open Common
 open Entities
+open Simulation.Skills.ImproveSkills
 
-let private doImprove band song maxQuality quality =
+let private improveSong' band song maxQuality quality =
     let songBeforeUpgrade = (song, maxQuality, quality)
     let increase = calculateQualityIncreaseOf maxQuality
     let updatedQuality = quality + increase
@@ -11,21 +12,19 @@ let private doImprove band song maxQuality quality =
 
     let songWithUpdatedQualities = (song, maxQuality, updatedQuality)
 
-    let status =
-        if canBeFurtherImproved then
-            CanBeImproved updatedQuality
-        else
-            ReachedMaxQualityInLastImprovement updatedQuality
+    let effect =
+        SongImproved(band, Diff(songBeforeUpgrade, songWithUpdatedQualities))
 
-    SongImproved(band, Diff(songBeforeUpgrade, songWithUpdatedQualities))
-    |> Effect.single
-    |> Tuple.two status
+    if canBeFurtherImproved then
+        CanBeImproved effect
+    else
+        ReachedMaxQualityInLastImprovement effect
 
 /// Orchestrates the improvement of a song, which calculates the increase that
 /// should happen in this action and returns whether the song can be further
 /// increased or not.
 let improveSong band (song, maxQuality, currentQuality) =
     if currentQuality >= maxQuality then
-        (ReachedMaxQualityAlready currentQuality, Effect.empty)
+        ReachedMaxQualityAlready
     else
-        doImprove band song maxQuality currentQuality
+        improveSong' band song maxQuality currentQuality

--- a/src/State/Skills.fs
+++ b/src/State/Skills.fs
@@ -1,0 +1,18 @@
+namespace State
+
+module Skills =
+    open Aether
+    open Aether.Operators
+    open Common
+    open Entities
+
+    let add map (character: Character) (skillWithLevel: SkillWithLevel) =
+        let (skill, _) = skillWithLevel
+
+        let skillLens =
+            Lenses.State.characterSkills_
+            >-> Map.key_ character.Id
+
+        let addSkill map = Map.add skill.Id skillWithLevel map
+
+        map (Optic.map skillLens addSkill)

--- a/src/State/State.fs
+++ b/src/State/State.fs
@@ -59,3 +59,5 @@ let apply effect =
     | MemberFired (band, currentMember, pastMember) ->
         Bands.removeMember staticAgent.Map band currentMember
         Bands.addPastMember staticAgent.Map band pastMember
+    | SkillImproved (character, Diff (_, skill)) ->
+        Skills.add staticAgent.Map character skill

--- a/src/State/State.fsproj
+++ b/src/State/State.fsproj
@@ -8,6 +8,7 @@
     <ItemGroup>
         <Compile Include="Songs.fs" />
         <Compile Include="Bands.fs" />
+        <Compile Include="Skills.fs" />
         <Compile Include="State.fs" />
         <Content Include="README.md" />
     </ItemGroup>

--- a/tests/Simulation.Tests/Bands/HireMember.Tests.fs
+++ b/tests/Simulation.Tests/Bands/HireMember.Tests.fs
@@ -20,12 +20,12 @@ let state =
         (Skill.createWithLevel (Genre dummyBand.Genre) skillLevel)
 
 let assertOnMembers assertion =
-    membersForHire state dummyBand instrument
+    membersForHire state dummyBand instrument.Type
     |> Seq.take 20
     |> Seq.iter assertion
 
 let memberForHire =
-    membersForHire state dummyBand instrument
+    membersForHire state dummyBand instrument.Type
     |> Seq.take 1
     |> Seq.head
 

--- a/tests/Simulation.Tests/Simulation.Tests.fsproj
+++ b/tests/Simulation.Tests/Simulation.Tests.fsproj
@@ -22,6 +22,7 @@
         <Compile Include="Songs\ImproveSong.Tests.fs" />
         <Compile Include="Songs\FinishSong.Tests.fs" />
         <Compile Include="Songs\DiscardSong.Tests.fs" />
+        <Compile Include="Skills\ImproveSkills.Tests.fs" />
         <Compile Include="Program.fs" />
     </ItemGroup>
 

--- a/tests/Simulation.Tests/Skills/ImproveSkills.Tests.fs
+++ b/tests/Simulation.Tests/Skills/ImproveSkills.Tests.fs
@@ -1,0 +1,55 @@
+module Simulation.Tests.Skills.ImproveSkills
+
+open NUnit.Framework
+open FsUnit
+open Test.Common
+
+open Entities
+open Simulation.Skills.ImproveSkills
+
+let unwrapDiff (Diff (_, (_, level))) = level
+
+let unwrapSkillImproved effect =
+    match effect with
+    | SkillImproved (_, diff) -> unwrapDiff diff
+    | _ -> invalidOp "Unexpected effect"
+
+let matchesImprovementValue effects =
+    let compositionLevel =
+        Seq.item 0 effects |> unwrapSkillImproved
+
+    let genreLevel =
+        Seq.item 1 effects |> unwrapSkillImproved
+
+    let instrumentLevel =
+        Seq.item 2 effects |> unwrapSkillImproved
+
+    compositionLevel |> should equal 1
+    genreLevel |> should equal 1
+    instrumentLevel |> should equal 1
+
+[<Test>]
+let ImproveBandSkillsAfterComposingShouldImproveRandomValuesIfRandomIsMoreThan50
+    ()
+    =
+    [ 60; 55; 51; 100; 78; 80 ]
+    |> List.iter
+        (fun randomValue ->
+            improveBandSkillsAfterComposing'
+                (fun _ _ -> randomValue)
+                dummyState
+                dummyBand
+            |> matchesImprovementValue)
+
+[<Test>]
+let ImproveBandSkillsAfterComposingShouldNotImproveIfRandomIsLessThanOrEqualTo50
+    ()
+    =
+    [ 1; 24; 12; 30; 45; 49; 50 ]
+    |> List.iter
+        (fun randomValue ->
+            improveBandSkillsAfterComposing'
+                (fun _ _ -> randomValue)
+                dummyState
+                dummyBand
+            |> should haveLength 0)

--- a/tests/Test.Common/Library.fs
+++ b/tests/Test.Common/Library.fs
@@ -21,13 +21,7 @@ let dummySong = Song.empty
 let dummyToday = Calendar.fromDayMonth 1 1
 
 let dummyState =
-    let bandWithMember =
-        Optic.map
-            Lenses.Band.members_
-            (List.append [ (Band.Member.from dummyCharacter Guitar dummyToday) ])
-            dummyBand
-
-    { Bands = Map.ofList [ (dummyBand.Id, bandWithMember) ]
+    { Bands = [ (dummyBand.Id, dummyBand) ] |> Map.ofSeq
       Character = dummyCharacter
       CharacterSkills = Map.ofList [ (dummyCharacter.Id, Map.empty) ]
       CurrentBandId = dummyBand.Id


### PR DESCRIPTION
This PR includes all the necessary functionality to improve the skills of the band's characters after they compose a new song or improve an existing one. More importantly, it also shapes the way that intertwined effects (such as Compose song -> Improve skill) are handled from now on with the introduction of `Galactus` (super bad name, working on a better one, just wanted to reference [this beauty](https://www.youtube.com/watch?v=y8OnoxKotPQ)).

This weirdly named module basically takes an effect and calls to other parts of the simulation code that should be called after that specific effect needs to be saved. The logic of calling this module is now in the `Orchestrator`, which means that any view only has to yield an effect to get it and all the related ones saved and displayed.