### PR TITLE
In-game money + Bank

### DIFF
--- a/src/Cli/Cli.fsproj
+++ b/src/Cli/Cli.fsproj
@@ -1,15 +1,16 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <Version>0.1.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="View\TextConstants.fs" />
     <Compile Include="View\Actions.fs" />
     <Compile Include="View\Common.fs" />
+    <Compile Include="View/Scenes/Bank/Bank.fs" />
+    <Compile Include="View/Scenes/Bank/Transfer.fs" />
     <Compile Include="View\Scenes\BandCreator.fs" />
     <Compile Include="View\Scenes\CharacterCreator.fs" />
     <Compile Include="View\Scenes\MainMenu.fs" />
@@ -29,15 +30,12 @@
     <Compile Include="Orchestrator.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Spectre.Console" Version="0.39.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Savegame\Savegame.fsproj" />
     <ProjectReference Include="..\Simulation\Simulation.fsproj" />
     <ProjectReference Include="..\State\State.fsproj" />
   </ItemGroup>
-
 </Project>

--- a/src/Cli/Text.fs
+++ b/src/Cli/Text.fs
@@ -21,10 +21,10 @@ let rec toString text =
 /// Returns the formatted instrument name given its type.
 and instrumentName instrumentType =
     match instrumentType with
-    | InstrumentType.Bass -> "Bass"
-    | InstrumentType.Drums -> "Drums"
-    | InstrumentType.Guitar -> "Guitar"
-    | InstrumentType.Vocals -> "Vocals"
+    | Bass -> "Bass"
+    | Drums -> "Drums"
+    | Guitar -> "Guitar"
+    | Vocals -> "Vocals"
 
 /// Returns the formatted skill name given its ID.
 and skillName id =
@@ -125,6 +125,7 @@ and fromConstant constant =
     | MapTitle -> "Map"
     | MapPrompt -> "Where are you heading?"
     | MapOptionRehearsalRoom -> "Band's rehearsal room"
+    | MapOptionBank -> "Bank"
     | RehearsalRoomTitle -> "Rehearsal Room"
     | RehearsalRoomCompose -> "Compose"
     | RehearsalRoomManage -> "Manage band"
@@ -237,3 +238,19 @@ and fromConstant constant =
             since.Year,
             until.Year
         )
+    | BankTitle -> "Bank"
+    | BankWelcome (characterBalance, bandBalance) ->
+        String.Format(
+            "[bold blue]You[/] currently have [green]{0}d$[/]. [bold blue]Your band[/] has: [green]{1}d$[/]",
+            characterBalance,
+            bandBalance
+        )
+    | BankPrompt -> "What do you want to do?"
+    | BankTransferToBand -> "Transfer money to band"
+    | BankTransferFromBand -> "Transfer money from band"
+    | BankTransferAmount holder ->
+        match holder with
+        | Character _ -> "How much do you want to transfer to your band?"
+        | Band _ -> "How much do you want to transfer from your band?"
+    | BankTransferSuccess -> "[bold green]The transference was completed successfully[/]"
+    | BankTransferNotEnoughFunds -> "[bold red]Not enough funds in the sender account[/]"

--- a/src/Cli/View/Actions.fs
+++ b/src/Cli/View/Actions.fs
@@ -14,6 +14,7 @@ type Scene =
     | Map
     | RehearsalRoom
     | Management
+    | Bank
 
 /// Defines the index of all sub-scenes available. Sub-scenes belong to a Scene
 /// and thus do not clear the screen or save a game.
@@ -26,6 +27,7 @@ type SubScene =
     | ManagementHireMember
     | ManagementFireMember
     | ManagementListMembers
+    | BankTransfer of sender: BankAccountHolder * receiver: BankAccountHolder
 
 /// Encapsulates text that can either be defined by a text constant, which is
 /// resolved by the UI layer, or a string constant that is just passed from this

--- a/src/Cli/View/Scenes/BandCreator.fs
+++ b/src/Cli/View/Scenes/BandCreator.fs
@@ -67,7 +67,7 @@ and handleConfirmation character name genre role confirmed =
             match (Band.from name genre members) with
             | Ok band ->
                 yield Effect <| startGame character band
-                yield Scene RehearsalRoom
+                yield Scene Map
             | Error Band.NameTooShort ->
                 yield!
                     seq {

--- a/src/Cli/View/Scenes/Bank/Bank.fs
+++ b/src/Cli/View/Scenes/Bank/Bank.fs
@@ -1,0 +1,63 @@
+module Cli.View.Scenes.Bank.Root
+
+open Cli.View.Actions
+open Cli.View.Common
+open Cli.View.TextConstants
+open Entities
+open Simulation.Queries
+
+let rehearsalOptions =
+    [ { Id = "transfer_to_band"
+        Text = TextConstant BankTransferToBand }
+      { Id = "transfer_from_band"
+        Text = TextConstant BankTransferFromBand } ]
+
+/// Creates the bank scene which allows to transfer money between accounts.
+let rec bankScene state =
+    let characterAccount =
+        Characters.playableCharacter state
+        |> fun character -> character.Id
+        |> Character
+
+    let bandAccount =
+        Bands.currentBand state
+        |> fun band -> band.Id
+        |> Band
+
+    let characterBalance = Bank.balanceOf state characterAccount
+    let bandBalance = Bank.balanceOf state bandAccount
+
+    seq {
+        yield Figlet <| TextConstant BankTitle
+
+        yield
+            BankWelcome(characterBalance, bandBalance)
+            |> TextConstant
+            |> Message
+
+        yield
+            Prompt
+                { Title = TextConstant BankPrompt
+                  Content =
+                      ChoicePrompt
+                      <| OptionalChoiceHandler
+                          { Choices = rehearsalOptions
+                            Handler =
+                                mapOptionalChoiceHandler
+                                <| processSelection characterAccount bandAccount
+                            BackText = TextConstant CommonBackToMap } }
+    }
+
+and processSelection characterAccount bandAccount choice =
+    seq {
+        match choice.Id with
+        | "transfer_to_band" ->
+            yield
+                SubScene
+                <| BankTransfer(characterAccount, bandAccount)
+        | "transfer_from_band" ->
+            yield
+                SubScene
+                <| BankTransfer(bandAccount, characterAccount)
+        | _ -> yield NoOp
+    }

--- a/src/Cli/View/Scenes/Bank/Transfer.fs
+++ b/src/Cli/View/Scenes/Bank/Transfer.fs
@@ -1,0 +1,33 @@
+module Cli.View.Scenes.Bank.Transfer
+
+open Cli.View.Actions
+open Cli.View.Common
+open Cli.View.TextConstants
+open Entities
+open Simulation.Bank.Transfer
+
+/// Asks for the amount that the user wants to transfer from the two accounts
+/// and confirms the transaction.
+let rec transferSubScene state sender receiver =
+    seq {
+        yield
+            Prompt
+                { Title = TextConstant <| BankTransferAmount receiver
+                  Content = NumberPrompt(handleAmount state sender receiver) }
+    }
+
+and handleAmount state sender receiver amount =
+    transfer state sender receiver (amount * 1<dd>)
+    |> fun result ->
+        match result with
+        | Ok effects ->
+            seq {
+                yield! Seq.map Effect effects
+                yield Message <| TextConstant BankTransferSuccess
+                yield SceneAfterKey Bank
+            }
+        | NotEnoughFunds ->
+            seq {
+                yield Message <| TextConstant BankTransferNotEnoughFunds
+                yield SceneAfterKey Bank
+            }

--- a/src/Cli/View/Scenes/Map.fs
+++ b/src/Cli/View/Scenes/Map.fs
@@ -9,6 +9,9 @@ let mapOptions =
         yield
             { Id = "rehearsal_room"
               Text = TextConstant MapOptionRehearsalRoom }
+        yield
+            { Id = "bank"
+              Text = TextConstant MapOptionBank }
     }
     |> List.ofSeq
 
@@ -32,5 +35,6 @@ and processSelection choice =
     seq {
         match choice.Id with
         | "rehearsal_room" -> yield Scene RehearsalRoom
+        | "bank" -> yield Scene Bank
         | _ -> yield NoOp
     }

--- a/src/Cli/View/Scenes/RehearsalRoom/RehearsalRoom.fs
+++ b/src/Cli/View/Scenes/RehearsalRoom/RehearsalRoom.fs
@@ -3,7 +3,6 @@ module Cli.View.Scenes.RehearsalRoom.Root
 open Cli.View.Actions
 open Cli.View.Common
 open Cli.View.TextConstants
-open Cli.View.Scenes.RehearsalRoom.Compose
 
 let rehearsalOptions =
     [ { Id = "compose"

--- a/src/Cli/View/TextConstants.fs
+++ b/src/Cli/View/TextConstants.fs
@@ -55,6 +55,7 @@ type TextConstant =
     | MapTitle
     | MapPrompt
     | MapOptionRehearsalRoom
+    | MapOptionBank
     | RehearsalRoomTitle
     | RehearsalRoomCompose
     | RehearsalRoomManage
@@ -116,3 +117,11 @@ type TextConstant =
         role: InstrumentType *
         from: Date *
         until: Date
+    | BankTitle
+    | BankWelcome of characterBalance: int<dd> * bandBalance: int<dd>
+    | BankPrompt
+    | BankTransferToBand
+    | BankTransferFromBand
+    | BankTransferAmount of holder: BankAccountHolder
+    | BankTransferSuccess
+    | BankTransferNotEnoughFunds

--- a/src/Common/Common.fsproj
+++ b/src/Common/Common.fsproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Database/Database.fsproj
+++ b/src/Database/Database.fsproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Entities/BankAccount.fs
+++ b/src/Entities/BankAccount.fs
@@ -1,9 +1,15 @@
 module Entities.BankAccount
 
 /// Creates a bank account for the given character ID.
-let forCharacter (id: CharacterId) =
+let forCharacter id =
     { Holder = Character id
       Transactions = [] }
 
+/// Creates a bank account for the given character ID with an initial transaction
+/// of the given balance.
+let forCharacterWithBalance id balance =
+    { Holder = Character id
+      Transactions = [ Incoming balance ] }
+
 /// Creates a bank account for the given band ID.
-let forBand (id: BandId) = { Holder = Band id; Transactions = [] }
+let forBand id = { Holder = Band id; Transactions = [] }

--- a/src/Entities/BankAccount.fs
+++ b/src/Entities/BankAccount.fs
@@ -1,0 +1,9 @@
+module Entities.BankAccount
+
+/// Creates a bank account for the given character ID.
+let forCharacter (id: CharacterId) =
+    { Holder = Character id
+      Transactions = [] }
+
+/// Creates a bank account for the given band ID.
+let forBand (id: BandId) = { Holder = Band id; Transactions = [] }

--- a/src/Entities/Entities.fsproj
+++ b/src/Entities/Entities.fsproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Entities/Entities.fsproj
+++ b/src/Entities/Entities.fsproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
         <Compile Include="Types.fs" />
+        <Compile Include="BankAccount.fs" />
         <Compile Include="Lenses.fs" />
         <Compile Include="Identity.fs" />
         <Compile Include="Calendar.fs" />

--- a/src/Entities/Lenses.fs
+++ b/src/Entities/Lenses.fs
@@ -58,6 +58,9 @@ module BandRepertoire =
 
 module FromState =
     module BankAccount =
+        /// Lens into a specific account.
+        let account_ id = State.bankAccounts_ >-> Map.key_ id
+
         /// Lens into the transactions of a specific bank account given the
         /// state and its id.
         let transactionsOf_ id =

--- a/src/Entities/Lenses.fs
+++ b/src/Entities/Lenses.fs
@@ -10,6 +10,10 @@ module State =
     let bands_ =
         (fun (s: State) -> s.Bands), (fun v (s: State) -> { s with Bands = v })
 
+    let bankAccounts_ =
+        (fun (s: State) -> s.BankAccounts),
+        (fun v (s: State) -> { s with BankAccounts = v })
+
     let bandRepertoire_ =
         (fun (s: State) -> s.BandRepertoire),
         (fun v (s: State) -> { s with BandRepertoire = v })
@@ -34,6 +38,15 @@ module Band =
         (fun (b: Band) -> b.PastMembers),
         (fun v (b: Band) -> { b with PastMembers = v })
 
+module BankAccount =
+    let holder_ =
+        (fun (b: BankAccount) -> b.Holder),
+        (fun v (b: BankAccount) -> { b with Holder = v })
+
+    let transactions_ =
+        (fun (b: BankAccount) -> b.Transactions),
+        (fun v (b: BankAccount) -> { b with Transactions = v })
+
 module BandRepertoire =
     let unfinished_ =
         (fun (br: BandRepertoire) -> br.Unfinished),
@@ -44,6 +57,13 @@ module BandRepertoire =
         (fun v (br: BandRepertoire) -> { br with Finished = v })
 
 module FromState =
+    module BankAccount =
+        /// Lens into the transactions of a specific bank account given the
+        /// state and its id.
+        let transactionsOf_ id =
+            State.bankAccounts_ >-> Map.key_ id
+            >?> BankAccount.transactions_
+
     module Bands =
         /// Lens into a specific band given the state and its id.
         let band_ id = State.bands_ >-> Map.key_ id

--- a/src/Entities/State.fs
+++ b/src/Entities/State.fs
@@ -9,4 +9,5 @@ let empty =
       CharacterSkills = Map.empty
       CurrentBandId = Identity.create () |> BandId
       BandRepertoire = Band.Repertoire.empty
+      BankAccounts = Map.empty
       Today = Calendar.fromDayMonth 1 1 }

--- a/src/Entities/Types.fs
+++ b/src/Entities/Types.fs
@@ -177,6 +177,30 @@ module Types =
         { Unfinished: SongsByBand<UnfinishedSongWithQualities>
           Finished: SongsByBand<FinishedSongWithQuality> }
 
+    /// Defines the before and after of an action.
+    type Diff<'a> = Diff of before: 'a * after: 'a
+
+    /// Measure for the in-game currency. DD as in DuetsDollars. Imagination
+    /// at its best.
+    [<Measure>]
+    type dd
+
+    /// Holder of an account in the in-game bank.
+    type BankAccountHolder =
+        | Character of CharacterId
+        | Band of BandId
+
+    /// Represents a transaction between two accounts in the game.
+    type BankTransaction =
+        | Incoming of sender: BankAccountHolder * amount: int<dd>
+        | Outgoing of receiver: BankAccountHolder * amount: int<dd>
+
+    /// Represents a bank account in the game. We only keep track of accounts
+    /// from the main character and its bands.
+    type BankAccount =
+        { Holder: BankAccountHolder
+          Transactions: BankTransaction list }
+
     /// Shared state of the game. Contains all state that is common to every part
     /// of the game.
     type State =
@@ -185,10 +209,8 @@ module Types =
           CharacterSkills: CharacterSkills
           CurrentBandId: BandId
           BandRepertoire: BandRepertoire
+          BankAccounts: Map<BankAccountHolder, BankAccount>
           Today: Date }
-
-    /// Defines the before and after of an action.
-    type Diff<'a> = Diff of before: 'a * after: 'a
 
     /// Defines an effect that happened after an action in the game. For example
     /// calling composeSong will create a `SongComposed` effect.
@@ -201,6 +223,7 @@ module Types =
         | MemberHired of Band * CurrentMember
         | MemberFired of Band * CurrentMember * PastMember
         | SkillImproved of Character * Diff<SkillWithLevel>
+        | MoneyTransfered of BankAccountHolder * BankTransaction
 
     /// Indicates whether the song can be further improved or if it has reached its
     /// maximum quality and thus cannot be improved. All variants wrap an int that

--- a/src/Entities/Types.fs
+++ b/src/Entities/Types.fs
@@ -192,8 +192,8 @@ module Types =
 
     /// Represents a transaction between two accounts in the game.
     type BankTransaction =
-        | Incoming of sender: BankAccountHolder * amount: int<dd>
-        | Outgoing of receiver: BankAccountHolder * amount: int<dd>
+        | Incoming of amount: int<dd>
+        | Outgoing of amount: int<dd>
 
     /// Represents a bank account in the game. We only keep track of accounts
     /// from the main character and its bands.
@@ -223,7 +223,7 @@ module Types =
         | MemberHired of Band * CurrentMember
         | MemberFired of Band * CurrentMember * PastMember
         | SkillImproved of Character * Diff<SkillWithLevel>
-        | MoneyTransfered of BankAccountHolder * BankTransaction
+        | MoneyTransferred of BankAccountHolder * BankTransaction
 
     /// Indicates whether the song can be further improved or if it has reached its
     /// maximum quality and thus cannot be improved. All variants wrap an int that

--- a/src/Savegame/Savegame.fsproj
+++ b/src/Savegame/Savegame.fsproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Simulation/Bank/Transfer.fs
+++ b/src/Simulation/Bank/Transfer.fs
@@ -1,0 +1,21 @@
+module Simulation.Bank.Transfer
+
+open Simulation.Queries
+open Entities
+
+type TransactionResult =
+    | Ok of Effect list
+    | NotEnoughFunds
+
+/// Transfers the given amount from `from` to `to` if possible, returning whether
+/// the transfer was successful or there was some error on the way.
+let transfer state sender receiver amount =
+    let accountBalance = Bank.balanceOf state sender
+
+    if accountBalance < amount then
+        NotEnoughFunds
+    else
+        Ok [ MoneyTransfered
+             <| (receiver, Incoming(sender, amount))
+             MoneyTransfered
+             <| (sender, Outgoing(receiver, amount)) ]

--- a/src/Simulation/Bank/Transfer.fs
+++ b/src/Simulation/Bank/Transfer.fs
@@ -15,7 +15,5 @@ let transfer state sender receiver amount =
     if accountBalance < amount then
         NotEnoughFunds
     else
-        Ok [ MoneyTransfered
-             <| (receiver, Incoming(sender, amount))
-             MoneyTransfered
-             <| (sender, Outgoing(receiver, amount)) ]
+        Ok [ MoneyTransferred <| (receiver, Incoming amount)
+             MoneyTransferred <| (sender, Outgoing amount) ]

--- a/src/Simulation/Queries/Bank.fs
+++ b/src/Simulation/Queries/Bank.fs
@@ -1,0 +1,17 @@
+namespace Simulation.Queries
+
+module Bank =
+    open Aether
+    open Entities
+
+    /// Returns the account balance of the given holder.
+    let balanceOf state holder =
+        state
+        |> Optic.get (Lenses.FromState.BankAccount.transactionsOf_ holder)
+        |> Option.defaultValue []
+        |> List.fold
+            (fun balance transaction ->
+                match transaction with
+                | Incoming (_, amount) -> balance + amount
+                | Outgoing (_, amount) -> balance - amount)
+            0<dd>

--- a/src/Simulation/Queries/Bank.fs
+++ b/src/Simulation/Queries/Bank.fs
@@ -12,6 +12,6 @@ module Bank =
         |> List.fold
             (fun balance transaction ->
                 match transaction with
-                | Incoming (_, amount) -> balance + amount
-                | Outgoing (_, amount) -> balance - amount)
+                | Incoming amount -> balance + amount
+                | Outgoing amount -> balance - amount)
             0<dd>

--- a/src/Simulation/Setup/StartGame.fs
+++ b/src/Simulation/Setup/StartGame.fs
@@ -10,5 +10,9 @@ let startGame character (band: Band) =
       CurrentBandId = band.Id
       Bands = [ (band.Id, band) ] |> Map.ofList
       BandRepertoire = Band.Repertoire.emptyFor band.Id
+      BankAccounts =
+          [ (Character character.Id, BankAccount.forCharacter character.Id)
+            (Band band.Id, BankAccount.forBand band.Id) ]
+          |> Map.ofSeq
       Today = Calendar.fromDayMonth 1 1 }
     |> GameCreated

--- a/src/Simulation/Setup/StartGame.fs
+++ b/src/Simulation/Setup/StartGame.fs
@@ -11,7 +11,8 @@ let startGame character (band: Band) =
       Bands = [ (band.Id, band) ] |> Map.ofList
       BandRepertoire = Band.Repertoire.emptyFor band.Id
       BankAccounts =
-          [ (Character character.Id, BankAccount.forCharacter character.Id)
+          [ (Character character.Id,
+             BankAccount.forCharacterWithBalance character.Id 1000<dd>)
             (Band band.Id, BankAccount.forBand band.Id) ]
           |> Map.ofSeq
       Today = Calendar.fromDayMonth 1 1 }

--- a/src/Simulation/Simulation.fsproj
+++ b/src/Simulation/Simulation.fsproj
@@ -1,5 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -7,11 +6,13 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <Compile Include="Queries/Bank.fs" />
         <Compile Include="Queries\Skills.fs" />
         <Compile Include="Queries\Characters.fs" />
         <Compile Include="Queries\Bands.fs" />
         <Compile Include="Queries\Songs.fs" />
         <Compile Include="Queries\Calendar.fs" />
+        <Compile Include="Bank\Transfer.fs" />
         <Compile Include="Setup\StartGame.fs" />
         <Compile Include="Bands\Members.fs" />
         <Compile Include="Skills\ImproveSkills.fs" />
@@ -29,7 +30,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Aether" Version="8.3.1" />
+        <PackageReference Include="Aether" Version="8.3.1" />
     </ItemGroup>
-
 </Project>

--- a/src/Simulation/Simulation.fsproj
+++ b/src/Simulation/Simulation.fsproj
@@ -3,6 +3,7 @@
         <TargetFramework>net5.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <RootNamespace>Simulation</RootNamespace>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/State/Bank.fs
+++ b/src/State/Bank.fs
@@ -1,0 +1,13 @@
+namespace State
+
+module Bank =
+    open Aether
+    open Entities
+
+    let transfer map account transaction =
+        let transactionsLens =
+            Lenses.FromState.BankAccount.transactionsOf_ account
+
+        let addTransaction = List.append [ transaction ]
+
+        map (Optic.map transactionsLens addTransaction)

--- a/src/State/State.fs
+++ b/src/State/State.fs
@@ -61,3 +61,5 @@ let apply effect =
         Bands.addPastMember staticAgent.Map band pastMember
     | SkillImproved (character, Diff (_, skill)) ->
         Skills.add staticAgent.Map character skill
+    | MoneyTransferred (account, transaction) ->
+        Bank.transfer staticAgent.Map account transaction

--- a/src/State/State.fsproj
+++ b/src/State/State.fsproj
@@ -1,20 +1,18 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <Compile Include="Songs.fs" />
-        <Compile Include="Bands.fs" />
-        <Compile Include="Skills.fs" />
-        <Compile Include="State.fs" />
-        <Content Include="README.md" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\Entities\Entities.fsproj" />
-    </ItemGroup>
-
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Bank.fs" />
+    <Compile Include="Songs.fs" />
+    <Compile Include="Bands.fs" />
+    <Compile Include="Skills.fs" />
+    <Compile Include="State.fs" />
+    <Content Include="README.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Entities\Entities.fsproj" />
+  </ItemGroup>
 </Project>

--- a/tests/Simulation.Tests/Bank/Queries.Tests.fs
+++ b/tests/Simulation.Tests/Bank/Queries.Tests.fs
@@ -1,0 +1,22 @@
+module Simulation.Tests.Bank.Queries
+
+open NUnit.Framework
+open FsUnit
+open Test.Common
+
+open Entities
+open Simulation.Queries.Bank
+
+[<Test>]
+let balanceOfShouldReturnCorrectBalance () =
+    let state =
+        dummyState
+        |> addFunds dummyCharacterBankAccount.Holder 100<dd>
+
+    balanceOf state dummyCharacterBankAccount.Holder
+    |> should equal 100
+
+[<Test>]
+let balanceOfUnknownShouldReturn0 () =
+    balanceOf dummyState (Character(CharacterId <| Identity.create ()))
+    |> should equal 0

--- a/tests/Simulation.Tests/Bank/Transfer.Tests.fs
+++ b/tests/Simulation.Tests/Bank/Transfer.Tests.fs
@@ -25,10 +25,8 @@ let transferAmountHigherThanBalanceShouldReturnNotEnoughFunds () =
 
 let createOk sender receiver amount =
     Ok
-    <| [ MoneyTransfered
-         <| (receiver, Incoming(sender, amount))
-         MoneyTransfered
-         <| (sender, Outgoing(receiver, amount)) ]
+    <| [ MoneyTransferred <| (receiver, Incoming amount)
+         MoneyTransferred <| (sender, Outgoing amount) ]
 
 [<Test>]
 let transferAmountLowerThanBalanceShouldReturnOkWithEffects () =

--- a/tests/Simulation.Tests/Bank/Transfer.Tests.fs
+++ b/tests/Simulation.Tests/Bank/Transfer.Tests.fs
@@ -1,0 +1,52 @@
+module Simulation.Tests.Bank.Transfer
+
+open NUnit.Framework
+open FsUnit
+open Test.Common
+
+open Entities
+open Simulation.Bank.Transfer
+
+let state =
+    dummyState
+    |> addFunds dummyCharacterBankAccount.Holder 100<dd>
+
+[<Test>]
+let transferAmountHigherThanBalanceShouldReturnNotEnoughFunds () =
+    [ 101<dd>; 120<dd>; 200<dd>; 500<dd> ]
+    |> List.iter
+        (fun amount ->
+            transfer
+                state
+                dummyCharacterBankAccount.Holder
+                dummyBandBankAccount.Holder
+                amount
+            |> should be (ofCase <@ NotEnoughFunds @>))
+
+let createOk sender receiver amount =
+    Ok
+    <| [ MoneyTransfered
+         <| (receiver, Incoming(sender, amount))
+         MoneyTransfered
+         <| (sender, Outgoing(receiver, amount)) ]
+
+[<Test>]
+let transferAmountLowerThanBalanceShouldReturnOkWithEffects () =
+    [ 20<dd>
+      30<dd>
+      99<dd>
+      1<dd>
+      54<dd> ]
+    |> List.iter
+        (fun amount ->
+            transfer
+                state
+                dummyCharacterBankAccount.Holder
+                dummyBandBankAccount.Holder
+                amount
+            |> should
+                equal
+                (createOk
+                    dummyCharacterBankAccount.Holder
+                    dummyBandBankAccount.Holder
+                    amount))

--- a/tests/Simulation.Tests/Simulation.Tests.fsproj
+++ b/tests/Simulation.Tests/Simulation.Tests.fsproj
@@ -18,6 +18,8 @@
     <ItemGroup>
         <Compile Include="Bands\HireMember.Tests.fs" />
         <Compile Include="Bands\FireMember.Tests.fs" />
+        <Compile Include="Bank\Transfer.Tests.fs" />
+        <Compile Include="Bank\Queries.Tests.fs" />
         <Compile Include="Songs\ComposeSong.Tests.fs" />
         <Compile Include="Songs\ImproveSong.Tests.fs" />
         <Compile Include="Songs\FinishSong.Tests.fs" />

--- a/tests/State.Tests/Bank.fs
+++ b/tests/State.Tests/Bank.fs
@@ -1,0 +1,39 @@
+module State.Tests.Bank
+
+open FsUnit
+open NUnit.Framework
+open Test.Common
+
+open Aether
+open Common
+open Entities
+
+[<SetUp>]
+let Setup () = initState ()
+
+[<Test>]
+let TransferShouldAddTransactionToBankAccount () =
+    let holder = dummyCharacterBankAccount.Holder
+
+    State.Root.apply
+    <| MoneyTransferred(holder, Incoming 100<dd>)
+
+    State.Root.apply
+    <| MoneyTransferred(holder, Outgoing 50<dd>)
+
+    let state = State.Root.get ()
+
+    let transactionLenses =
+        Lenses.FromState.BankAccount.transactionsOf_ holder
+
+    let transactions =
+        Optic.get transactionLenses state
+        |> Option.defaultValue []
+
+    transactions |> should haveLength 2
+
+    List.head transactions
+    |> should equal (Outgoing 50<dd>)
+
+    List.item 1 transactions
+    |> should equal (Incoming 100<dd>)

--- a/tests/State.Tests/State.Tests.fsproj
+++ b/tests/State.Tests/State.Tests.fsproj
@@ -1,32 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-
-        <IsPackable>false</IsPackable>
-        <GenerateProgramFile>false</GenerateProgramFile>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Aether" Version="8.3.1" />
-        <PackageReference Include="FsUnit" Version="4.0.4" />
-        <PackageReference Include="NUnit" Version="3.13.2" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <Compile Include="Common.fs" />
-        <Compile Include="BandManagement.fs" />
-        <Compile Include="SongComposition.fs" />
-        <Compile Include="Setup.fs" />
-        <Compile Include="Program.fs" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\Entities\Entities.fsproj" />
-      <ProjectReference Include="..\..\src\State\State.fsproj" />
-      <ProjectReference Include="..\Test.Common\Test.Common.fsproj" />
-    </ItemGroup>
-
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateProgramFile>false</GenerateProgramFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Aether" Version="8.3.1" />
+    <PackageReference Include="FsUnit" Version="4.0.4" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Common.fs" />
+    <Compile Include="Bank.fs" />
+    <Compile Include="BandManagement.fs" />
+    <Compile Include="SongComposition.fs" />
+    <Compile Include="Setup.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Entities\Entities.fsproj" />
+    <ProjectReference Include="..\..\src\State\State.fsproj" />
+    <ProjectReference Include="..\Test.Common\Test.Common.fsproj" />
+  </ItemGroup>
 </Project>

--- a/tests/Test.Common/Library.fs
+++ b/tests/Test.Common/Library.fs
@@ -20,6 +20,14 @@ let dummySong = Song.empty
 
 let dummyToday = Calendar.fromDayMonth 1 1
 
+let dummyCharacterBankAccount =
+    BankAccount.forCharacter dummyCharacter.Id
+
+let dummyBandBankAccount = BankAccount.forBand dummyBand.Id
+
+let dummyTargetBankAccount =
+    BankAccount.forCharacter (CharacterId(Identity.create ()))
+
 let dummyState =
     { Bands = [ (dummyBand.Id, dummyBand) ] |> Map.ofSeq
       Character = dummyCharacter
@@ -28,6 +36,9 @@ let dummyState =
       BandRepertoire =
           { Unfinished = Map.ofList [ (dummyBand.Id, Map.empty) ]
             Finished = Map.ofList [ (dummyBand.Id, Map.empty) ] }
+      BankAccounts =
+          Map.ofList [ (Character dummyCharacter.Id, dummyCharacterBankAccount)
+                       (Band dummyBand.Id, dummyBandBankAccount) ]
       Today = dummyToday }
 
 /// Adds a given member to the given band.
@@ -77,3 +88,12 @@ let addFinishedSong (band: Band) finishedSong =
         Lenses.FromState.Songs.finishedByBand_ band.Id
 
     Optic.map finishedSongLenses (Map.add song.Id finishedSong)
+
+/// Adds the specified funds to the given account.
+let addFunds account amount state =
+    let add transactions =
+        List.append
+            transactions
+            [ Incoming(dummyTargetBankAccount.Holder, amount) ]
+
+    Optic.map (Lenses.FromState.BankAccount.transactionsOf_ account) add state

--- a/tests/Test.Common/Library.fs
+++ b/tests/Test.Common/Library.fs
@@ -92,8 +92,6 @@ let addFinishedSong (band: Band) finishedSong =
 /// Adds the specified funds to the given account.
 let addFunds account amount state =
     let add transactions =
-        List.append
-            transactions
-            [ Incoming(dummyTargetBankAccount.Holder, amount) ]
+        List.append transactions [ Incoming amount ]
 
     Optic.map (Lenses.FromState.BankAccount.transactionsOf_ account) add state


### PR DESCRIPTION
This PR adds an in-game currency called Duets Dollars (or d$). Because imagination. And also the ability to manage the character's and band's money by transferring money between them. This currency only supports integers to make everything simpler. At the start of the game the character gets 1000d$ automatically.

This will come in handy later with the introduction of studios and the ability to record since this will require money to do so. 

As a plus all projects now fail if they contain incomplete pattern matches since the warning is borderline useless.