### PR TITLE
:arrow_up: Use .NET 7.0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:7.0
 
 COPY *.sln .
 COPY src ./src


### PR DESCRIPTION
This is the missing part of the changes introduced in 3d95161bb948f8c37f85af25d7bc6d8213c02cb4.
Now it is been able to build Duets in Docker again!

BTW, it is long ago from my last time checking your project, @sleepyfran. I can see many significant improvements, looks great!